### PR TITLE
Update pihole Statistik

### DIFF
--- a/pihole Statistik
+++ b/pihole Statistik
@@ -1,9 +1,11 @@
 # AdBlock (Pihole) Statistik auslesen und in fhem anzeigen
 # https://pi-hole.net/
+# parameter bei extractAllJSON ergänzt
+# API aufruf Key benötigt
 
 define AdBlockInfo HTTPMOD http://127.0.0.1/admin/api.php 120
-attr AdBlockInfo extractAllJSON
+attr AdBlockInfo extractAllJSON 2
 attr AdBlockInfo userattr getURL
-attr AdBlockInfo getURL http://127.0.0.1/admin/api.php
+attr AdBlockInfo getURL http://127.0.0.1/admin/api.php?summary&auth=<api key> #Key in pi.hole abrufbar
 attr AdBlockInfo stateFormat DNS Anfragen: dns_queries_today | Geblockte Werbung : ads_blocked_today (ads_percentage_today %)
 attr AdBlockInfo room Info


### PR DESCRIPTION
Parameter bei extractAllJSON ergänzt - in FHEM benötigt API aufruf Key benötigt - aktuelles Pihole benötigt zum auslesen des Parameter "summary" und einen API Key. Key in Pihole abrufbar unter settings - API -"Show API Token" siehe auch: https://pi-hole.net/blog/2022/11/17/upcoming-changes-authentication-for-more-api-endpoints-required/#page-content